### PR TITLE
Require Node.js 24 Active LTS for GenieACS stack RPMs

### DIFF
--- a/SPECS/genieacs-sim.spec
+++ b/SPECS/genieacs-sim.spec
@@ -7,6 +7,7 @@ Group: Applications/Communications
 License: MIT
 URL: https://github.com/genieacs/genieacs-sim
 
+# DEPRECATED – will not build on modern NodeJS versions
 BuildRequires: gcc-c++, libxml2, npm
 Requires: nodejs
 

--- a/SPECS/genieacs.spec
+++ b/SPECS/genieacs.spec
@@ -1,14 +1,18 @@
 Name: genieacs
 Version: 1.2.13
-Release: 2
+Release: 3
 Summary: A fast and lightweight TR-069 Auto Configuration Server (ACS)
 
 Group: Applications/Communications
 License: AGPLv3
 URL: https://%{name}.com/
 
-BuildRequires: npm
-Requires: mongodb-org-server, nodejs
+# Node.js 24 Active LTS (DNF module nodejs:24). EL9 modular RPMs need epoch in Requires:
+#   nodejs >= 1:24, nodejs < 1:25  (plain "nodejs < 25" does not resolve in dnf builddep).
+# Staging fallback if 24 fails: nodejs:22 with nodejs >= 1:22, nodejs < 1:23.
+BuildRequires: nodejs >= 1:24, nodejs < 1:25, npm
+Requires: mongodb-org-server
+Requires: nodejs >= 1:24, nodejs < 1:25
 
 %description
 GenieACS is an open source TR-069 remote management solution with advanced
@@ -89,6 +93,9 @@ install -d %{buildroot}%{_datadir}/%{name}/ext
 %attr(755, nobody, nobody) %{_localstatedir}/log/%{name}
 
 %changelog
+* Wed May 27 2026 NMS Prime <patrick.reichel@nmsprime.com> - 1.2.13-3
+- Require Node.js 24.x Active LTS (>= 1:24, < 1:25) for runtime and build
+
 * Mon Apr 07 2025 Nino Ryschawy <nino.ryschawy@nmsprime.com> - 1.2.13-2
 - Fix logrote startup error on missing genieacs log file
 

--- a/SPECS/nodejs-axios-nmsprime.spec
+++ b/SPECS/nodejs-axios-nmsprime.spec
@@ -1,26 +1,32 @@
 Name: nodejs-axios-nmsprime
 Version: 1.6.8
-Release: 1
+Release: 2
 Summary: Promise based HTTP client for the browser and node.js
 Group: Applications/Communications
 License: MIT
 BuildArch: noarch
 URL: https://github.com/axios/axios
 
-BuildRequires: npm
-Requires: nodejs
+# Node.js 24 Active LTS (DNF module nodejs:24). EL9 modular RPMs need epoch in Requires:
+#   nodejs >= 1:24, nodejs < 1:25  (plain "nodejs < 25" does not resolve in dnf builddep).
+# Staging fallback if 24 fails: nodejs:22 with nodejs >= 1:22, nodejs < 1:23.
+BuildRequires: nodejs >= 1:24, nodejs < 1:25, npm
+Requires: nodejs >= 1:24, nodejs < 1:25
 
 %description
 Promise based HTTP client for the browser and node.js
 
 %install
 CACHE_DIR=$(mktemp -d)
-npm install axios --cache "$CACHE_DIR" --loglevel warn --global true --prefix %{buildroot}
+npm install axios@%{version} --cache "$CACHE_DIR" --loglevel warn --global true --prefix %{buildroot}
 rm -rf "$CACHE_DIR"
 
 %files
 /lib/node_modules/axios/*
 
 %changelog
+* Wed May 27 2026 NMS Prime <patrick.reichel@nmsprime.com> - 1.6.8-2
+- Require Node.js 24.x Active LTS (>= 1:24, < 1:25); pin axios@%{version} at build time
+
 * Wed Apr 24 2024 Ole Ernst <ole.ernst@nmsprime.com> - 1.6.8-1
 - Initial RPM release

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,79 @@
 #!/bin/bash
+set -euo pipefail
+
 if [ $# -ne 1 ]; then
 	echo "Usage: $0 SPECS/<specfile>" >&2
 	exit 1
 fi
 SPEC="$1"
 
+# Active LTS major for GenieACS / nodejs-axios RPMs (Maintenance LTS fallback: 22).
+# Version installed at the build machine Needs to be the same version as in the .spec files
+NODE_LTS_MAJOR=24
+
 cd "$(dirname "$0")"
+
+spec_needs_nodejs_lts() {
+	case "$SPEC" in
+		SPECS/genieacs.spec | SPECS/nodejs-axios*.spec)
+			return 0
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+node_major_version() {
+	if ! command -v node >/dev/null 2>&1; then
+		echo 0
+		return
+	fi
+	local ver="${1:-$(node -v)}"
+	ver="${ver#v}"
+	echo "${ver%%.*}"
+}
+
+ensure_nodejs_lts() {
+	local major
+	major=$(node_major_version)
+
+	if [ "$major" -eq "$NODE_LTS_MAJOR" ]; then
+		echo "Node.js $(node -v) OK for build (Active LTS ${NODE_LTS_MAJOR}.x)." >&2
+		return 0
+	fi
+
+	echo "ERROR: ${SPEC} requires Node.js ${NODE_LTS_MAJOR}.x (Active LTS)." >&2
+	if [ "$major" -gt 0 ]; then
+		echo "  Found: $(node -v)" >&2
+	fi
+	echo "  Fallback if runtime issues appear on staging: nodejs:22 (Maintenance LTS, Requires >= 22 and < 23)." >&2
+
+	if [ "$(id -u)" -eq 0 ] && command -v dnf >/dev/null 2>&1; then
+		echo "Attempting dnf module switch to nodejs:${NODE_LTS_MAJOR}..." >&2
+		dnf -y module reset nodejs
+		dnf -y module enable "nodejs:${NODE_LTS_MAJOR}"
+		dnf -y module install "nodejs:${NODE_LTS_MAJOR}/common"
+		dnf -y install npm
+
+		major=$(node_major_version)
+		if [ "$major" -eq "$NODE_LTS_MAJOR" ]; then
+			echo "Node.js $(node -v) ready." >&2
+			return 0
+		fi
+	fi
+
+	echo "On the build host run:" >&2
+	echo "  sudo dnf -y module reset nodejs" >&2
+	echo "  sudo dnf -y module enable nodejs:${NODE_LTS_MAJOR}" >&2
+	echo "  sudo dnf -y module install nodejs:${NODE_LTS_MAJOR}/common" >&2
+	echo "  sudo dnf -y install npm" >&2
+	exit 1
+}
+
+if spec_needs_nodejs_lts; then
+	ensure_nodejs_lts
+fi
 
 for FOLDER in BUILD BUILDROOT SOURCES; do
 	rm -rf "$FOLDER"


### PR DESCRIPTION
Pin nodejs >= 1:24 and < 1:25 on genieacs and nodejs-axios-nmsprime (EL9 modular packages need epoch-qualified bounds). Teach build.sh to enforce nodejs:24 on the rpmbuild host before npm-based builds.

genieacs-sim is outdated and will not build on modern NodeJS versions.

If staging shows GenieACS issues on 24, fall back to Maintenance LTS: nodejs:22 with Requires >= 1:22 and < 1:23.


NodeJS v16 is out of maintenance since 2023, v24 is the current LTS release.